### PR TITLE
Chore/Only lint staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     }
   },
   "lint-staged": {
-    "*.js": "npm run lint"
+    "*.js": "eslint"
   }
 }


### PR DESCRIPTION
Previously, the lint-staged config for JS files runs `npm run build` which lints all the files. Changing this command to `eslint` only lints the currently-staged files, which is the original intent of this hook.